### PR TITLE
Fix expansion board detection (Conflict with RF_DATA)

### DIFF
--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -471,6 +471,9 @@ void OpenSprinkler::begin() {
   lcd.createChar(3, lcd_rain_char);
   lcd.createChar(4, lcd_connect_char);
 
+  // Expansion detection
+  pinMode(PIN_EXP_SENSE, INPUT);
+
   // set button pins
   // enable internal pullup
   pinMode(PIN_BUTTON_1, INPUT);

--- a/defines.h
+++ b/defines.h
@@ -177,7 +177,7 @@ typedef enum {
   #define PIN_BUTTON_1      31    // button 1
   #define PIN_BUTTON_2      30    // button 2
   #define PIN_BUTTON_3      29    // button 3 
-  #define PIN_RF_DATA       28    // RF data pin 
+  #define PIN_RF_DATA       27    // RF data pin 
   #define PORT_RF        PORTA
   #define PINX_RF        PINA3
   #define PIN_SR_LATCH       3    // shift register latch pin


### PR DESCRIPTION
The RF Data pin is A3 (27), not A4 (28) as defined in defines.h.
This causes the initialization of the RF pin to pull the EXP_SENSE
pin to 0V breaking detection of expansion boards.

Additionally, the PIN_EXP_SENSE is now initialized to INPUT.