### PR TITLE
Fix logging broken on 32-bit Linux systems with 64-bit time_t

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1775,7 +1775,7 @@ void write_log(unsigned char type, time_os_t curr_time) {
 	if (!os.iopts[IOPT_ENABLE_LOGGING]) return;
 
 	// file name will be logs/xxxxx.tx where xxxxx is the day in epoch time
-	snprintf (tmp_buffer, TMP_BUFFER_SIZE, "%lu", curr_time / 86400);
+	snprintf (tmp_buffer, TMP_BUFFER_SIZE, "%lu", (unsigned long)(curr_time / 86400));
 	make_logfile_name(tmp_buffer);
 
 	// Step 1: open file if exists, or create new otherwise,
@@ -1876,7 +1876,7 @@ void write_log(unsigned char type, time_os_t curr_time) {
 	}
 	strcat_P(tmp_buffer, PSTR(","));
 	size_t size = strlen(tmp_buffer);
-	snprintf(tmp_buffer + size, TMP_BUFFER_SIZE - size , "%lu", curr_time);
+	snprintf(tmp_buffer + size, TMP_BUFFER_SIZE - size , "%lu", (unsigned long)curr_time);
 	if((os.iopts[IOPT_SENSOR1_TYPE]==SENSOR_TYPE_FLOW) && (type==LOGDATA_STATION)) {
 		// RAH implementation of flow sensor
 		strcat_P(tmp_buffer, PSTR(","));


### PR DESCRIPTION
## Problem

On modern 32-bit Linux systems (Raspberry Pi with recent Debian/Raspbian), 
the logging system produces corrupted log files with garbage filenames and 
timestamps. The `/jl` API endpoint returns empty results even though log 
files exist in the `logs/` directory.

### Root Cause

Since glibc 2.34, `time_t` is 64-bit on 32-bit systems to address the 
year 2038 problem. The logging code passes `time_os_t` (which is `time_t`) 
directly to `snprintf` with `%lu` format specifier, which expects 32-bit 
`unsigned long`. This type mismatch causes undefined behavior.

### Symptoms

- Log files created with incorrect names (e.g., `5212016.txt` instead of `20420.txt`)
- Timestamps in log entries are garbage values
- `/jl?hist=7` API returns `[]` because expected filenames don't exist
- Issue manifests on 32-bit ARM Linux with glibc >= 2.34

## Solution

Explicitly cast `time_os_t` values to `unsigned long` before passing to 
`snprintf` with `%lu`:

// Before
```cpp
snprintf(tmp_buffer, TMP_BUFFER_SIZE, "%lu", curr_time / 86400);
```

// After  
```cpp
snprintf(tmp_buffer, TMP_BUFFER_SIZE, "%lu", (unsigned long)(curr_time / 86400));
```

Tested on:
- Raspberry Pi (armv7l, 32-bit)
- Debian (dietpi) with glibc 2.41
- Confirmed log files now have correct day-based filenames
- Confirmed `/jl` API returns expected log entries

This should be tested on other devices to make sure it doesn't break it for those other devices. I only have this one raspberry pi so it's all I could test with.