### PR TITLE
Extend multi-day averaging (MDA) to weekly programs

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -888,13 +888,16 @@ void do_loop()
 						if (wt_restricted > 0) wl = 0; // if watering restriction is active
 						else {
 							wl = os.iopts[IOPT_WATER_PERCENTAGE];
-							// If historical data is enabled and interval program, overwrite watering percentage with historical one.
-							if (mda == 100 && prog.type == PROGRAM_TYPE_INTERVAL && md_N > 0) {
-								// Use interval length unless longer than available data
-								if ((unsigned int)prog.days[1]-1 < md_N){
-									wl = md_scales[prog.days[1]-1];
-								} else {
-									wl = md_scales[md_N-1];
+							// If multi-day averaging is enabled, use historical watering data
+							if (mda == 100 && md_N > 0) {
+								int dsl = prog.days_since_last(curr_time);
+								if (dsl > 0) {
+									unsigned int idx = (unsigned int)(dsl - 1);
+									if (idx < md_N) {
+										wl = md_scales[idx];
+									} else {
+										wl = md_scales[md_N - 1];
+									}
 								}
 							}
 						}

--- a/program.cpp
+++ b/program.cpp
@@ -224,25 +224,59 @@ int16_t ProgramStruct::starttime_decode(int16_t t) {
 	return t;
 }
 
+/** Get weekday from timestamp. Returns 0=Monday, 6=Sunday. */
+unsigned char ProgramStruct::get_weekday(time_os_t t) {
+#if defined(ARDUINO)
+	unsigned char weekday_t = weekday(t);
+#else
+	time_os_t ct = t;
+	struct tm *ti = gmtime(&ct);
+	unsigned char weekday_t = (ti->tm_wday+1)%7;
+#endif
+	return (weekday_t+5)%7;
+}
+
+/** Calculate days since last scheduled run for MDA purposes.
+ *  Returns -1 if not applicable to this program type.
+ */
+int ProgramStruct::days_since_last(time_os_t t) {
+	switch(type) {
+		case PROGRAM_TYPE_INTERVAL:
+			return days[1];
+
+		case PROGRAM_TYPE_WEEKLY: {
+			unsigned char wd = get_weekday(t);
+			// Walk backwards through bit vector to find previous run day
+			for (unsigned char i = 1; i <= 7; i++) {
+				unsigned char prev_day = (wd - i + 7) % 7;
+				if (days[0] & (1 << prev_day)) {
+					return i;
+				}
+			}
+			return -1;
+		}
+
+		default:
+			return -1;
+	}
+}
+
 /** Check if a given time matches the program's start day */
 unsigned char ProgramStruct::check_day_match(time_os_t t) {
 
-#if defined(ARDUINO)  // get current time from Arduino
-	unsigned char weekday_t = weekday(t);  // weekday ranges from [0,6] within Sunday being 1
+#if defined(ARDUINO)
 	unsigned char day_t = day(t);
 	unsigned char month_t = month(t);
 	unsigned char year_t = year(t);
-#else // get current time from RPI/LINUX
+#else
 	time_os_t ct = t;
 	struct tm *ti = gmtime(&ct);
-	unsigned char weekday_t = (ti->tm_wday+1)%7;  // tm_wday ranges from [0,6] with Sunday being 0
 	unsigned char day_t = ti->tm_mday;
-	unsigned char month_t = ti->tm_mon+1;  // tm_mon ranges from [0,11]
-	unsigned char year_t = ti->tm_year+1900; // tm_year is years since 1900
-#endif // get current time
+	unsigned char month_t = ti->tm_mon+1;
+	unsigned char year_t = ti->tm_year+1900;
+#endif
 
 	int epoch_t = (t / 86400);
-	unsigned char wd = (weekday_t+5)%7;
 	unsigned char dt = day_t;
 
 	if(en_daterange) { // check date range if enabled
@@ -258,11 +292,12 @@ unsigned char ProgramStruct::check_day_match(time_os_t t) {
 
 	// check day match
 	switch(type) {
-		case PROGRAM_TYPE_WEEKLY:
+		case PROGRAM_TYPE_WEEKLY: {
 			// weekday match
+			unsigned char wd = get_weekday(t);
 			if (!(days[0] & (1<<wd)))
 				return 0;
-		break;
+		} break;
 
 		case PROGRAM_TYPE_SINGLERUN:
 			// check match of exact day

--- a/program.h
+++ b/program.h
@@ -107,6 +107,8 @@ public:
 	unsigned char check_match(time_os_t t, bool *to_delete);
 	void gen_station_runorder(uint16_t runcount, unsigned char *order);
 	int16_t starttime_decode(int16_t t);
+	int days_since_last(time_os_t t);
+	static unsigned char get_weekday(time_os_t t); // returns 0=Monday, 6=Sunday
 
 protected:
 


### PR DESCRIPTION
Extract get_weekday() helper from check_day_match() and add days_since_last() method to ProgramStruct. This allows weekly programs to use the md_scales[] array for weather-based watering level adjustments, matching the existing interval program behavior.