### PR TITLE
Fix all logs being written to '0.txt'

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1880,7 +1880,11 @@ void write_log(unsigned char type, time_os_t curr_time) {
 	}
 	strcat_P(tmp_buffer, PSTR(","));
 	size_t size = strlen(tmp_buffer);
+#if defined(ARDUINO)
 	snprintf(tmp_buffer + size, TMP_BUFFER_SIZE - size , "%lu", curr_time);
+#else
+	snprintf(tmp_buffer + size, TMP_BUFFER_SIZE - size , "%lld", curr_time);
+#endif
 	if((os.iopts[IOPT_SENSOR1_TYPE]==SENSOR_TYPE_FLOW) && (type==LOGDATA_STATION)) {
 		// RAH implementation of flow sensor
 		strcat_P(tmp_buffer, PSTR(","));

--- a/main.cpp
+++ b/main.cpp
@@ -1775,7 +1775,11 @@ void write_log(unsigned char type, time_os_t curr_time) {
 	if (!os.iopts[IOPT_ENABLE_LOGGING]) return;
 
 	// file name will be logs/xxxxx.tx where xxxxx is the day in epoch time
+#if defined(ARDUINO)
 	snprintf (tmp_buffer, TMP_BUFFER_SIZE, "%lu", curr_time / 86400);
+#else
+	snprintf (tmp_buffer, TMP_BUFFER_SIZE, "%lld", curr_time / 86400);
+#endif
 	make_logfile_name(tmp_buffer);
 
 	// Step 1: open file if exists, or create new otherwise,


### PR DESCRIPTION
A cleaner solution for [!405](https://github.com/OpenSprinkler/OpenSprinkler-Firmware/issues/405) than https://github.com/OpenSprinkler/OpenSprinkler-Firmware/pull/383